### PR TITLE
added pysafebrowsing.__version__

### DIFF
--- a/pysafebrowsing/__init__.py
+++ b/pysafebrowsing/__init__.py
@@ -1,1 +1,2 @@
 from .api import SafeBrowsing
+from .about import __title__, __version__

--- a/pysafebrowsing/about.py
+++ b/pysafebrowsing/about.py
@@ -1,0 +1,2 @@
+__version__ = "0.1.2"  # single source of version ID
+__title__ = "pysafebrowsing"

--- a/setup.py
+++ b/setup.py
@@ -3,26 +3,29 @@ from setuptools import setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+with open("pysafebrowsing/about.py") as f:
+    v = f.read()
+    for l in v.split("\n"):
+        if l.startswith("__version__"):
+            __version__ = l.split('"')[-2]
+
 setup(
-    name='pysafebrowsing',
-    version='0.1.1',
-    description='Google Safe Browsing API python wrapper',
+    name="pysafebrowsing",
+    version=__version__,
+    description="Google Safe Browsing API python wrapper",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='https://github.com/Te-k/pysafebrowsing',
-    author='Tek',
-    author_email='tek@randhome.io',
-    keywords='security',
-    install_requires=['requests', 'configparser'],
-    license='MIT',
-    packages=['pysafebrowsing'],
-    entry_points= {
-        'console_scripts': [ 'safebrowsing=pysafebrowsing.cli:main' ]
-    },
+    url="https://github.com/Te-k/pysafebrowsing",
+    author="Tek",
+    author_email="tek@randhome.io",
+    keywords="security",
+    install_requires=["requests", "configparser"],
+    license="MIT",
+    packages=["pysafebrowsing"],
+    entry_points={"console_scripts": ["safebrowsing=pysafebrowsing.cli:main"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-    ]
-
+    ],
 )


### PR DESCRIPTION
added pysafebrowsing.__version__, which allows users to check the version number of the package within python using the syntax:

```
import pysafebrowsing
pysafebrowsing.__version__
```

I have also updated the setup.py such that there isn't multiple sources of version IDs. Additionally, I have bumped the version number to 0.1.2.