### PR TITLE
Ensure all chunks are scanned

### DIFF
--- a/pysafebrowsing/api.py
+++ b/pysafebrowsing/api.py
@@ -72,7 +72,7 @@ class SafeBrowsing(object):
                 # Return clean results
                 if r.json() == {}:
 
-                    results.update(dict([(u, {"malicious": False}) for u in urls]))
+                    results.update(dict([(u, {"malicious": False}) for u in urll]))
                 else:
                     for url in urll:
                         # Get matches
@@ -101,7 +101,7 @@ class SafeBrowsing(object):
                     raise SafeBrowsingPermissionDenied(r.json()['error']['message'])
                 else:
                     raise SafeBrowsingWeirdError(r.status_code, "", "", "")
-            return results
+        return results
 
     def lookup_url(self, url, platforms=["ANY_PLATFORM"]):
         """


### PR DESCRIPTION
Really cool project! Just a minor update to ensure all chunks are considered. 

` for u in urls` on line 75 will overwrite previously malicious results. I believe this should be `urll` instead to only update the current chunk. 

The indentation level of `return results` is also updated. 

In the test below we want to make sure the malware testing page is still marked as malicious. 
```
for i in range(25):
  domains.append( "http://example.com/before_page_"+str(i) )

domains.append( "http://malware.testing.google.test/testing/malware/")

for i in range(25):
  domains.append( "http://example.com/after_page_"+str(i) )

r = s.lookup_urls(domains)
```